### PR TITLE
8.3: Fix build error

### DIFF
--- a/SOURCES/systemtap-4.0-Fix-compilation.xcpng8.3.patch
+++ b/SOURCES/systemtap-4.0-Fix-compilation.xcpng8.3.patch
@@ -1,0 +1,34 @@
+From e03b5f2fcc06ef3967fe3204ab9c0d6b3511ab6a Mon Sep 17 00:00:00 2001
+From: Thierry Escande <thierry.escande@vates.tech>
+Date: Wed, 22 Jan 2025 09:35:57 +0100
+Subject: [PATCH] Fix mistyped array of integers causing build to fail
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+This array of size_t integers is used as width specifiers for strings
+passed to *printf functions. But printf needs int types as width
+specifiers so changed the array type to unsigned int. It needs to be
+unsigned since this array entries are compared to unsigned values (using
+the locally defined MAX() macro).
+
+Signed-off-by: Thierry Escande <thierry.escande@vates.tech>
+---
+ staprun/monitor.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/staprun/monitor.c b/staprun/monitor.c
+index 478634c..96536ba 100644
+--- a/staprun/monitor.c
++++ b/staprun/monitor.c
+@@ -364,7 +364,7 @@ void monitor_render(void)
+       int printed;
+       int col;
+       int i;
+-      size_t width[num_attributes] = {0};
++      unsigned int width[num_attributes] = {0};
+       json_object *jso_uptime, *jso_uid, *jso_mem,
+                   *jso_name, *jso_globals, *jso_probe_list;
+       struct json_object_iterator it, it_end;
+-- 
+2.45.2
+

--- a/SPECS/systemtap.spec
+++ b/SPECS/systemtap.spec
@@ -92,7 +92,7 @@
 
 Name: systemtap
 Version: 4.0
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.1%{?dist}
 # for version, see also configure.ac
 
 
@@ -129,6 +129,9 @@ License: GPLv2+
 URL: http://sourceware.org/systemtap/
 #Source: ftp://sourceware.org/pub/systemtap/releases/systemtap-%%{version}.tar.gz
 Source0: systemtap-4.0.tar.gz
+
+# XCP-ng specific patches
+Patch1000: systemtap-4.0-Fix-compilation.xcpng8.3.patch
 
 # Build*
 BuildRequires: gcc-c++
@@ -540,6 +543,9 @@ sleep 1
 find . \( -name configure -o -name config.h.in \) -print | xargs touch
 cd ..
 %endif
+
+# XCP-ng patches
+%patch1000 -p1
 
 %{?_cov_prepare}
 
@@ -1295,6 +1301,9 @@ done
 
 # PRERELEASE
 %changelog
+* Wed Jan 22 2025 Thierry Escande <thierry.escande@vates.tech> - 4.0-5.1
+- Fix build error
+
 * Mon Feb 14 2022 Ross Lagerwall <ross.lagerwall@citrix.com> - 4.0-5
 - CP-38416: Enable static analysis
 


### PR DESCRIPTION
This change adds a patch that fixes a build error related to a mistyped array of unsigned integers that are used as width specifiers for *printf calls.